### PR TITLE
Use env variables for Supabase client

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ To deploy the Supabase edge functions:
 
 This project relies on Supabase for backend services. Make sure to set up the following environment variables in your Supabase project:
 
+- `SUPABASE_URL`: The base URL of your Supabase instance
+- `SUPABASE_PUBLISHABLE_KEY`: Your Supabase publishable API key
 - `OPENAI_API_KEY`: Your OpenAI API key for the assistant feature
 - `GEMINI_API_KEY`: Your Google Gemini API key for the AI insights
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,15 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://mxtsdgkwzjzlttpotole.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im14dHNkZ2t3emp6bHR0cG90b2xlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDcxMDUyNTksImV4cCI6MjA2MjY4MTI1OX0.2KM8JxBEsqQidSvjhuLs8HCX-7g-q6YNswedQ5ZYq3g";
+const SUPABASE_URL =
+  (typeof import.meta !== 'undefined' && import.meta.env?.SUPABASE_URL) ||
+  process.env.SUPABASE_URL ||
+  '';
+
+const SUPABASE_PUBLISHABLE_KEY =
+  (typeof import.meta !== 'undefined' && import.meta.env?.SUPABASE_PUBLISHABLE_KEY) ||
+  process.env.SUPABASE_PUBLISHABLE_KEY ||
+  '';
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- load Supabase connection details from environment variables
- list SUPABASE_URL and SUPABASE_PUBLISHABLE_KEY in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845fd93a3e0832eb9faeab083e62d2d