### PR TITLE
Externalize secrets via env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Database password for PostgreSQL services
+POSTGRES_PASSWORD=your_postgres_password
+
+# Read-only user password used by init-db.sql
+VORTEX_READONLY_PASSWORD=your_readonly_password
+
+# Redis authentication password
+REDIS_PASSWORD=your_redis_password
+
+# Kong database password
+KONG_PG_PASSWORD=your_kong_db_password
+
+# SMTP credentials for auth-service emails
+SMTP_PASS=your_app_password
+
+# Grafana admin password
+GF_SECURITY_ADMIN_PASSWORD=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       POSTGRES_DB: vortex_auth
       POSTGRES_USER: vortex_user
-      POSTGRES_PASSWORD: vortex_password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
@@ -32,7 +32,7 @@ services:
   # Redis Cache
   redis:
     image: redis:7-alpine
-    command: redis-server --appendonly yes --requirepass vortex_redis_password
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
     volumes:
       - redis_data:/data
     ports:
@@ -53,8 +53,8 @@ services:
     environment:
       NODE_ENV: development
       PORT: 3001
-      DATABASE_URL: postgresql://vortex_user:vortex_password@postgres:5432/vortex_auth
-      REDIS_URL: redis://:vortex_redis_password@redis:6379
+      DATABASE_URL: postgresql://vortex_user:${POSTGRES_PASSWORD}@postgres:5432/vortex_auth
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
       JWT_SECRET: your-super-secret-jwt-key-change-in-production-32-chars-min
       JWT_REFRESH_SECRET: your-super-secret-refresh-key-change-in-production-32-chars-min
       JWT_EXPIRES_IN: 15m
@@ -63,7 +63,7 @@ services:
       SMTP_HOST: smtp.gmail.com
       SMTP_PORT: 587
       SMTP_USER: your-email@gmail.com
-      SMTP_PASS: your-app-password
+      SMTP_PASS: ${SMTP_PASS}
       CORS_ORIGIN: http://localhost:8083
       LOG_LEVEL: info
       ENABLE_REQUEST_LOGGING: "true"
@@ -91,7 +91,7 @@ services:
     environment:
       POSTGRES_DB: kong
       POSTGRES_USER: kong
-      POSTGRES_PASSWORD: kong_password
+      POSTGRES_PASSWORD: ${KONG_PG_PASSWORD}
     volumes:
       - ./kong/postgres_data:/var/lib/postgresql/data
     networks:
@@ -109,7 +109,7 @@ services:
       KONG_DATABASE: postgres
       KONG_PG_HOST: kong-database
       KONG_PG_USER: kong
-      KONG_PG_PASSWORD: kong_password
+      KONG_PG_PASSWORD: ${KONG_PG_PASSWORD}
       KONG_PG_DATABASE: kong
     depends_on:
       kong-database:
@@ -123,7 +123,7 @@ services:
       KONG_DATABASE: postgres
       KONG_PG_HOST: kong-database
       KONG_PG_USER: kong
-      KONG_PG_PASSWORD: kong_password
+      KONG_PG_PASSWORD: ${KONG_PG_PASSWORD}
       KONG_PG_DATABASE: kong
       KONG_ADMIN_LISTEN: 0.0.0.0:8001
       KONG_PROXY_LISTEN: 0.0.0.0:8000
@@ -171,7 +171,7 @@ services:
       - "3000:3000"
     environment:
       GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -20,7 +20,7 @@ GRANT ALL PRIVILEGES ON DATABASE vortex_analytics TO vortex_user;
 GRANT ALL PRIVILEGES ON DATABASE vortex_notifications TO vortex_user;
 
 -- Create read-only user for analytics
-CREATE USER vortex_readonly WITH PASSWORD 'vortex_readonly_password';
+CREATE USER vortex_readonly WITH PASSWORD '${VORTEX_READONLY_PASSWORD}';
 GRANT CONNECT ON DATABASE vortex_auth TO vortex_readonly;
 GRANT CONNECT ON DATABASE vortex_accounts TO vortex_readonly;
 GRANT CONNECT ON DATABASE vortex_transactions TO vortex_readonly;


### PR DESCRIPTION
## Summary
- parameterize readonly DB password in init script
- reference env vars for passwords in `docker-compose.yml`
- provide an example `.env` file listing required variables

## Testing
- `npm run lint` *(fails: unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845fdf510bc832e95a8dcd2307e060c