### PR TITLE
Use env vars for Supabase client

### DIFF
--- a/PRODUCTION_DEPLOYMENT_CHECKLIST.md
+++ b/PRODUCTION_DEPLOYMENT_CHECKLIST.md
@@ -39,6 +39,8 @@
   REDIS_URL=<production-redis>
   CORS_ORIGIN=<your-production-domain>
   FORCE_HTTPS=true
+  VITE_SUPABASE_URL=<your-supabase-url>
+  VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
   ```
 
 - [ ] **SSL/TLS Configuration**

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ This project relies on Supabase for backend services. Make sure to set up the fo
 
 - `OPENAI_API_KEY`: Your OpenAI API key for the assistant feature
 - `GEMINI_API_KEY`: Your Google Gemini API key for the AI insights
+- `VITE_SUPABASE_URL`: URL of your Supabase project
+- `VITE_SUPABASE_ANON_KEY`: Supabase anonymous key used by the frontend
 
 ### Edge Functions
 
@@ -102,6 +104,8 @@ For web deployment, you can use any static site hosting platform:
 
 1. Build the production version:
    ```sh
+   # Ensure environment variables like VITE_SUPABASE_URL and
+   # VITE_SUPABASE_ANON_KEY are defined before building
    npm run build
    ```
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://mxtsdgkwzjzlttpotole.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im14dHNkZ2t3emp6bHR0cG90b2xlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDcxMDUyNTksImV4cCI6MjA2MjY4MTI1OX0.2KM8JxBEsqQidSvjhuLs8HCX-7g-q6YNswedQ5ZYq3g";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- use `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in Supabase client
- document new environment variables for builds and deployment

## Testing
- `npm run lint` *(fails: 27 errors, 17 warnings)*
- `npm test` *(fails: Missing script)*
- `bash security-hardening.sh` *(fails: Forbidden while running npm audit)*

------
https://chatgpt.com/codex/tasks/task_e_684604e2c7f8832e846f676585e62bb1