### PR TITLE
Add Vitest configuration and sample tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test:ai": "tsx src/test-ai.ts"
+    "test:ai": "tsx src/test-ai.ts",
+    "test": "vitest"
   },
   "dependencies": {
     "@capacitor/cli": "^7.2.0",
@@ -87,6 +88,9 @@
     "tsx": "^4.19.4",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^1.4.0",
+    "jsdom": "^24.0.0",
+    "@testing-library/react": "^14.0.0"
   }
 }

--- a/src/hooks/__tests__/use-mobile.test.tsx
+++ b/src/hooks/__tests__/use-mobile.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook, act } from '@testing-library/react'
+import { useIsMobile } from '../use-mobile'
+import { vi } from 'vitest'
+
+describe('useIsMobile', () => {
+  beforeEach(() => {
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: query.includes('max-width: 767px'),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  })
+
+  it('detects mobile viewport', () => {
+    const hook = renderHook(() => useIsMobile())
+    expect(hook.result.current).toBe(true)
+  })
+})

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from '../utils'
+
+describe('cn', () => {
+  it('combines class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('ignores falsy values', () => {
+    expect(cn('foo', false && 'bar', 'baz')).toBe('foo baz')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add test script using vitest and install dev dependencies
- configure vitest with jsdom environment
- add sample unit tests for `cn` util and `useIsMobile` hook

## Testing
- `npm test` *(fails: `vitest` not found)*
- `bash security-hardening.sh` *(fails: npm audit 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846052c541c832e8c8762e33c8945ed